### PR TITLE
disable initsystem

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -17,7 +17,7 @@ RUN apk add --no-cache make gcc g++ python && \
 COPY ./app ./
 
 # Enable systemd init system in container
-ENV INITSYSTEM=on
+# ENV INITSYSTEM=on
 
 # server.js will run when container starts up on the device
 CMD ["bash", "/usr/src/app/start.sh"]


### PR DESCRIPTION
fixes #7 

there is a bug in the latest alpine images that happens only when initsystem is enabled. This is not just a temporary solution since we want node-red to be restarted if it crashes